### PR TITLE
Added new PV+BridgeDb versions in line with pom.xml

### DIFF
--- a/localsetup.sh
+++ b/localsetup.sh
@@ -1,9 +1,9 @@
 # pathvisio core
-mvn install:install-file -Dfile=localRepo/org.pathvisio.core.jar -DgroupId=org.pathvisio -DartifactId=pathvisio-core -Dversion=3.2.2 -Dpackaging=jar
+mvn install:install-file -Dfile=localRepo/org.pathvisio.core.jar -DgroupId=org.pathvisio -DartifactId=pathvisio-core -Dversion=3.3.0 -Dpackaging=jar
 
 # bridgedb 
-mvn install:install-file -Dfile=localRepo/org.bridgedb.jar -DgroupId=org.bridgedb -DartifactId=bridgedb -Dversion=2.0.0 -Dpackaging=jar
-mvn install:install-file -Dfile=localRepo/org.bridgedb.bio.jar -DgroupId=org.bridgedb -DartifactId=bridgedb-bio -Dversion=2.0.0 -Dpackaging=jar
+mvn install:install-file -Dfile=localRepo/org.bridgedb.jar -DgroupId=org.bridgedb -DartifactId=bridgedb -Dversion=3.0.13 -Dpackaging=jar
+mvn install:install-file -Dfile=localRepo/org.bridgedb.bio.jar -DgroupId=org.bridgedb -DartifactId=bridgedb-bio -Dversion=3.0.13 -Dpackaging=jar
 mvn install:install-file -Dfile=localRepo/derby.jar -DgroupId=derby -DartifactId=derby -Dversion=10.4 -Dpackaging=jar
 
 # xml parsing


### PR DESCRIPTION
@mkutmon @AlexanderPico this change resolves the first issues I have with the dependencies.
I only have an issues left with the "springsource artifact; the pom.xml requires version 2.0.1, but I cannot seem to download that with the following line:
```
mvn install:install-file -Dfile=localRepo/com.springsource.org.jdom-2.0.1.jar -DgroupId=com.springsource -DartifactId=org.jdom -Dversion=2.0.1 -Dpackaging=jar
```
